### PR TITLE
Add location to score metrics

### DIFF
--- a/openio/openio.go
+++ b/openio/openio.go
@@ -29,10 +29,15 @@ import (
 
 type serviceType []string
 
+type serviceTag struct {
+	Location string `json:"tag.loc"`
+}
+
 type serviceInfo []struct {
 	Addr  string
 	Score int
 	Local bool
+	Tags serviceTag
 }
 
 type cntr struct {
@@ -221,7 +226,12 @@ func collectScore(proxyURL string, ns string, sType string, c chan netdata.Metri
 		for i := range sInfo {
 			if util.IsSameHost(sInfo[i].Addr) {
 				sInfo[i].Local = true
-				netdata.Update("score", util.SID(sType+"_"+sInfo[i].Addr, ns), fmt.Sprint(sInfo[i].Score), c)
+				netdata.Update("score",
+					util.SID(
+						sType+"_"+sInfo[i].Addr,
+						ns,
+						util.FmtLocation(sInfo[i].Tags.Location),
+					), fmt.Sprint(sInfo[i].Score), c)
 			} else {
 				sInfo[i].Local = false
 			}

--- a/util/util.go
+++ b/util/util.go
@@ -116,10 +116,15 @@ func RaiseIf(err error) {
 	}
 }
 
+// FmtLocation -- format location string
+func FmtLocation(location string) string {
+	return strings.Replace(location, ".", "/", -1)
+}
+
 // SID -- Get a service ID for netdata
-func SID(service string, ns string, volume ...string) string {
-	if (len(volume) > 0) && (volume[0] != "") {
-		return fmt.Sprintf("%s.%s.%s", ns, mReplacer.Replace(service), volume[0])
+func SID(service string, ns string, extra ...string) string {
+	if (len(extra) > 0) && (extra[0] != "") {
+		return fmt.Sprintf("%s.%s.%s", ns, mReplacer.Replace(service), extra[0])
 	}
 	return fmt.Sprintf("%s.%s", ns, mReplacer.Replace(service))
 }


### PR DESCRIPTION
New dimensions look like this:
```
netdata_openio_score__average{chart="openio.score",dimension="OPENIO.meta0_10_0_0_120_6001.sds-gw2/0",family="Score",instance="sds-gw2",job="netdata",module="netdata",s_instance="10_0_0_120_6001.sds-gw2/0",service="meta0"}
```

Spec is: `[NS].[INSTANCE].[LOCATION]`