### PR TITLE
Add volume name to capacity metrics

### DIFF
--- a/openio/openio.go
+++ b/openio/openio.go
@@ -205,7 +205,7 @@ func volumeInfo(service string, ns string, volume string, c chan netdata.Metric)
 		return
 	}
 	for dim, val := range info {
-		netdata.Update(dim, util.SID(service, ns, fsid), fmt.Sprint(val), c)
+		netdata.Update(dim, util.SID(service, ns, fsid + "." + volume), fmt.Sprint(val), c)
 	}
 }
 


### PR DESCRIPTION
This adds volume name to the dimension in openio capacity metrics. FSID is retained as it is necessary to group capacity when multiple services are deployed on the same volume.

```
netdata_openio_byte_avail__average{chart="openio.byte_avail",dimension="OPENIO.10_0_0_120_6110.18446744072638540332./mnt/ssd1/OPENIO/meta1-0",family="Capacity",instance="sds-gw2",job="netdata",module="netdata",s_instance="10_0_0_120_6110"}
```

Spec: `[NS].[INSTANCE].[FSID].[VOLUME]`