### PR TITLE
FS Collector: add support for multiple endpoints

### DIFF
--- a/cmd/command.plugin/command.plugin.go
+++ b/cmd/command.plugin/command.plugin.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"oionetdata/collector"
-	"oionetdata/netdata"
-	"oionetdata/openio"
 	"oionetdata/command"
+	"oionetdata/netdata"
+	"oionetdata/util"
 )
 
 func main() {
@@ -42,7 +42,7 @@ func main() {
 
 	cmds := make(map[string]command.Command)
 
-	out, err := openio.Commands(conf)
+	out, err := util.Commands(conf)
 	if err != nil {
 		log.Fatalln("ERROR: Command plugin: Could not load commands", err)
 	}
@@ -54,7 +54,7 @@ func main() {
 	log.Printf("INFO: Command plugin: Loaded %d commands", len(cmds))
 
 	writer := netdata.NewDefaultWriter()
-	worker := netdata.NewWorker(time.Duration(intervalSeconds)*time.Second, writer, nil)
+	worker := netdata.NewWorker(time.Duration(intervalSeconds)*time.Second, writer)
 	collector := command.NewCollector(cmds, cmdInterval, worker)
 	worker.SetCollector(collector)
 

--- a/cmd/fs.plugin/fs.plugin.go
+++ b/cmd/fs.plugin/fs.plugin.go
@@ -27,150 +27,163 @@ import (
 	"oionetdata/collector"
 	"oionetdata/netdata"
 	"oionetdata/oiofs"
+	"oionetdata/util"
 )
 
 func main() {
 	if len(os.Args) < 2 {
 		log.Fatalf("argument required")
 	}
-	var addr string
-	var id string
+	var conf string
 	var full bool
 	fs := flag.NewFlagSet("", flag.ExitOnError)
-	fs.StringVar(&addr, "addr", "localhost:6999", "IP:PORT of oiofs stats route")
-	fs.StringVar(&id, "id", "default", "Connector identifier (alphanumeric)")
+	fs.StringVar(&conf, "conf", "/etc/netdata/oiofs.conf", "Path to endpoint config file")
 	fs.BoolVar(&full, "full", false, "Gather all metrics")
 	fs.Parse(os.Args[2:])
 	intervalSeconds := collector.ParseIntervalSeconds(os.Args[1])
 
+	var endpoints []oiofs.Endpoint
+
+	out, err := util.OiofsEndpoints(conf)
+	if err != nil {
+		log.Fatalln("ERROR: Oiofs plugin: Could not load oiofs endpoints", err)
+	}
+
+	for name, url := range out {
+		endpoints = append(endpoints, oiofs.Endpoint{Path: name, URL: url})
+	}
+
 	writer := netdata.NewDefaultWriter()
-	collector := oiofs.NewCollector(addr, full)
-	worker := netdata.NewWorker(time.Duration(intervalSeconds)*time.Second, writer, collector)
+	worker := netdata.NewWorker(time.Duration(intervalSeconds)*time.Second, writer)
 
-	fsType := fmt.Sprintf("oiofs_%s", id)
-	family := "oiofs"
+	for _, endpoint := range endpoints {
+		collector := oiofs.NewCollector(endpoint, full)
+		worker.AddCollector(collector)
+		family := endpoint.Path
+		fsType := fmt.Sprintf("oiofs.%s", endpoint.Path)
 
-	if full {
-		// Metadata counters
-		metaCount := netdata.NewChart(fsType, "meta_count", "", "Metadata Counters", "ops", family, "oiofs.meta")
-		for _, op := range oiofs.Ops["metaDebug"] {
-			metaCount.AddDimension(
-				fmt.Sprintf("Meta_%s_count", strings.Title(op)),
-				strings.TrimSpace(op),
-				netdata.IncrementalAlgorithm,
-			)
+		if full {
+			// Metadata counters
+			metaCount := netdata.NewChart(fsType, "meta_count", "", "Metadata Counters", "ops", family, "oiofs.meta.")
+			for _, op := range oiofs.Ops["metaDebug"] {
+				metaCount.AddDimension(
+					fmt.Sprintf("Meta_%s_count", strings.Title(op)),
+					strings.TrimSpace(op),
+					netdata.IncrementalAlgorithm,
+				)
+			}
+			worker.AddChart(metaCount, collector)
+
+			// Metadata latency
+			metaLatency := netdata.NewChart(fsType, "meta_latency", "", "Metadata latency", "us", family, "oiofs.meta_latency")
+			for _, op := range oiofs.Ops["metaDebug"] {
+				metaLatency.AddDimension(
+					fmt.Sprintf("Meta_%s_total_us", strings.Title(op)),
+					strings.TrimSpace(op),
+					netdata.AbsoluteAlgorithm,
+				)
+			}
+			worker.AddChart(metaLatency, collector)
 		}
-		worker.AddChart(metaCount)
 
-		// Metadata latency
-		metaLatency := netdata.NewChart(fsType, "meta_latency", "", "Metadata latency", "us", family, "oiofs.meta_latency")
-		for _, op := range oiofs.Ops["metaDebug"] {
-			metaLatency.AddDimension(
-				fmt.Sprintf("Meta_%s_total_us", strings.Title(op)),
-				strings.TrimSpace(op),
-				netdata.AbsoluteAlgorithm,
-			)
+		// Cache size
+		cacheSizeStats := netdata.NewChart(fsType, "cache_size", "", "Cache Size", "bytes", family, "oiofs.cache_size")
+		cacheSizeStats.AddDimension("cache_chunk_used_byte", "used", netdata.AbsoluteAlgorithm)
+		cacheSizeStats.AddDimension("cache_chunk_total_byte", "total", netdata.AbsoluteAlgorithm)
+		cacheSizeStats.AddDimension("cache_read_total_byte", "read", netdata.AbsoluteAlgorithm)
+		worker.AddChart(cacheSizeStats, collector)
+
+		// Cache age
+		cacheAgeStats := netdata.NewChart(fsType, "cache_age", "", "Cache age", "us", family, "oiofs.cache_age")
+		cacheAgeStats.AddDimension("cache_chunk_avg_age_microseconds", "age", netdata.AbsoluteAlgorithm)
+		worker.AddChart(cacheAgeStats, collector)
+
+		// Cache latency
+		cacheLatency := netdata.NewChart(fsType, "cache_latency", "", "Cache latency", "us", family, "oiofs.cache_latency")
+		cacheLatency.AddDimension("cache_read_total_us", "read", netdata.AbsoluteAlgorithm)
+		worker.AddChart(cacheLatency, collector)
+
+		// Cache read
+		cacheReadStats := netdata.NewChart(fsType, "cache_read", "", "Cache read", "ops", family, "oiofs.cache")
+		cacheReadStats.AddDimension("cache_read_count", "total", netdata.IncrementalAlgorithm)
+		cacheReadStats.AddDimension("cache_read_hit", "hit", netdata.IncrementalAlgorithm)
+		cacheReadStats.AddDimension("cache_read_miss", "miss", netdata.IncrementalAlgorithm)
+		worker.AddChart(cacheReadStats, collector)
+
+		// Cache chunks
+		cacheChunks := netdata.NewChart(fsType, "cache_chunks", "", "Cache chunks", "chunks", family, "oiofs.cache")
+		cacheChunks.AddDimension("cache_chunk_count", "chunks", netdata.AbsoluteAlgorithm)
+		worker.AddChart(cacheChunks, collector)
+
+		if full {
+			// Fuse counters
+			fuseCount := netdata.NewChart(fsType, "fuse_count", "", "Fuse counters", "ops", family, "oiofs.fuse")
+			for _, op := range oiofs.Ops["fuseDebug"] {
+				fuseCount.AddDimension(
+					fmt.Sprintf("fuse_%s_count", op),
+					strings.TrimSpace(op),
+					netdata.IncrementalAlgorithm,
+				)
+			}
+			worker.AddChart(fuseCount, collector)
+
+			// Fuse latency
+			fuseLatency := netdata.NewChart(fsType, "fuse_latency", "", "Fuse latency", "us", family, "oiofs.fuse_latency")
+			for _, op := range oiofs.Ops["fuseDebug"] {
+				fuseLatency.AddDimension(
+					fmt.Sprintf("fuse_%s_total_us", op),
+					strings.TrimSpace(op),
+					netdata.AbsoluteAlgorithm,
+				)
+			}
+			worker.AddChart(fuseLatency, collector)
 		}
-		worker.AddChart(metaLatency)
+
+		// Fuse I/O
+		fuseIO := netdata.NewChart(fsType, "fuse_io", "", "Fuse I/O", "bytes", family, "oiofs.fuse")
+		fuseIO.AddDimension("fuse_read_total_byte", "read", netdata.IncrementalAlgorithm)
+		fuseIO.AddDimension("fuse_write_total_byte", "write", netdata.IncrementalAlgorithm)
+		worker.AddChart(fuseIO, collector)
+
+		if full {
+			// SDS counters
+			sdsCount := netdata.NewChart(fsType, "sds_count", "", "SDS counters", "ops", family, "oiofs.sds")
+			for _, op := range oiofs.Ops["sdsDebug"] {
+				sdsCount.AddDimension(
+					fmt.Sprintf("sds_%s_count", strings.Title(op)),
+					strings.TrimSpace(op),
+					netdata.IncrementalAlgorithm,
+				)
+			}
+			worker.AddChart(sdsCount, collector)
+
+			// SDS latency
+			sdsLatency := netdata.NewChart(fsType, "sds_latency", "", "SDS latency", "us", family, "oiofs.sds_latency")
+			for _, op := range oiofs.Ops["sdsDebug"] {
+				sdsLatency.AddDimension(
+					fmt.Sprintf("fuse_%s_count", strings.Title(op)),
+					strings.TrimSpace(op),
+					netdata.IncrementalAlgorithm,
+				)
+			}
+			worker.AddChart(sdsLatency, collector)
+		}
+
+		sdsUpload := netdata.NewChart(fsType, "sds_upload", "", "SDS uploads", "ops", family, "oiofs.sds_ul")
+		sdsUpload.AddDimension("sds_upload_failed", "failed", netdata.IncrementalAlgorithm)
+		sdsUpload.AddDimension("sds_upload_succeeded", "succeeded", netdata.IncrementalAlgorithm)
+		worker.AddChart(sdsUpload, collector)
+
+		sdsDownload := netdata.NewChart(fsType, "sds_download", "", "SDS downloads", "ops", family, "oiofs.sds_dl")
+		sdsDownload.AddDimension("sds_download_failed", "failed", netdata.IncrementalAlgorithm)
+		sdsDownload.AddDimension("sds_download_succeeded", "succeeded", netdata.IncrementalAlgorithm)
+		worker.AddChart(sdsDownload, collector)
+
+		sdsData := netdata.NewChart(fsType, "sds_data", "", "SDS data", "bytes", family, "oiofs.sds")
+		sdsData.AddDimension("sds_download_total_byte", "download", netdata.IncrementalAlgorithm)
+		sdsData.AddDimension("sds_upload_total_byte", "upload", netdata.IncrementalAlgorithm)
+		worker.AddChart(sdsData, collector)
 	}
-
-	// Cache size
-	cacheSizeStats := netdata.NewChart(fsType, "cache_size", "", "Cache Size", "bytes", family, "oiofs.cache_size")
-	cacheSizeStats.AddDimension("cache_chunk_used_byte", "used", netdata.AbsoluteAlgorithm)
-	cacheSizeStats.AddDimension("cache_chunk_total_byte", "total", netdata.AbsoluteAlgorithm)
-	cacheSizeStats.AddDimension("cache_read_total_byte", "read", netdata.AbsoluteAlgorithm)
-	worker.AddChart(cacheSizeStats)
-
-	// Cache age
-	cacheAgeStats := netdata.NewChart(fsType, "cache_age", "", "Cache age", "us", family, "oiofs.cache_age")
-	cacheAgeStats.AddDimension("cache_chunk_avg_age_microseconds", "age", netdata.AbsoluteAlgorithm)
-	worker.AddChart(cacheAgeStats)
-
-	// Cache latency
-	cacheLatency := netdata.NewChart(fsType, "cache_latency", "", "Cache latency", "us", family, "oiofs.cache_latency")
-	cacheLatency.AddDimension("cache_read_total_us", "read", netdata.AbsoluteAlgorithm)
-	worker.AddChart(cacheLatency)
-
-	// Cache read
-	cacheReadStats := netdata.NewChart(fsType, "cache_read", "", "Cache read", "ops", family, "oiofs.cache")
-	cacheReadStats.AddDimension("cache_read_count", "total", netdata.IncrementalAlgorithm)
-	cacheReadStats.AddDimension("cache_read_hit", "hit", netdata.IncrementalAlgorithm)
-	cacheReadStats.AddDimension("cache_read_miss", "miss", netdata.IncrementalAlgorithm)
-	worker.AddChart(cacheReadStats)
-
-	// Cache chunks
-	cacheChunks := netdata.NewChart(fsType, "cache_chunks", "", "Cache chunks", "chunks", family, "oiofs.cache")
-	cacheChunks.AddDimension("cache_chunk_count", "chunks", netdata.AbsoluteAlgorithm)
-	worker.AddChart(cacheChunks)
-
-	if full {
-		// Fuse counters
-		fuseCount := netdata.NewChart(fsType, "fuse_count", "", "Fuse counters", "ops", family, "oiofs.fuse")
-		for _, op := range oiofs.Ops["fuseDebug"] {
-			fuseCount.AddDimension(
-				fmt.Sprintf("fuse_%s_count", op),
-				strings.TrimSpace(op),
-				netdata.IncrementalAlgorithm,
-			)
-		}
-		worker.AddChart(fuseCount)
-
-		// Fuse latency
-		fuseLatency := netdata.NewChart(fsType, "fuse_latency", "", "Fuse latency", "us", family, "oiofs.fuse_latency")
-		for _, op := range oiofs.Ops["fuseDebug"] {
-			fuseLatency.AddDimension(
-				fmt.Sprintf("fuse_%s_total_us", op),
-				strings.TrimSpace(op),
-				netdata.AbsoluteAlgorithm,
-			)
-		}
-		worker.AddChart(fuseLatency)
-	}
-
-	// Fuse I/O
-	fuseIO := netdata.NewChart(fsType, "fuse_io", "", "Fuse I/O", "bytes", family, "oiofs.fuse")
-	fuseIO.AddDimension("fuse_read_total_byte", "read", netdata.IncrementalAlgorithm)
-	fuseIO.AddDimension("fuse_write_total_byte", "write", netdata.IncrementalAlgorithm)
-	worker.AddChart(fuseIO)
-
-	if full {
-		// SDS counters
-		sdsCount := netdata.NewChart(fsType, "sds_count", "", "SDS counters", "ops", family, "oiofs.sds")
-		for _, op := range oiofs.Ops["sdsDebug"] {
-			sdsCount.AddDimension(
-				fmt.Sprintf("sds_%s_count", strings.Title(op)),
-				strings.TrimSpace(op),
-				netdata.IncrementalAlgorithm,
-			)
-		}
-		worker.AddChart(sdsCount)
-
-		// SDS latency
-		sdsLatency := netdata.NewChart(fsType, "sds_latency", "", "SDS latency", "us", family, "oiofs.sds_latency")
-		for _, op := range oiofs.Ops["sdsDebug"] {
-			sdsLatency.AddDimension(
-				fmt.Sprintf("fuse_%s_count", strings.Title(op)),
-				strings.TrimSpace(op),
-				netdata.IncrementalAlgorithm,
-			)
-		}
-		worker.AddChart(sdsLatency)
-	}
-
-	sdsUpload := netdata.NewChart(fsType, "sds_upload", "", "SDS uploads", "ops", family, "oiofs.sds_ul")
-	sdsUpload.AddDimension("sds_upload_failed", "failed", netdata.IncrementalAlgorithm)
-	sdsUpload.AddDimension("sds_upload_succeeded", "succeeded", netdata.IncrementalAlgorithm)
-	worker.AddChart(sdsUpload)
-
-	sdsDownload := netdata.NewChart(fsType, "sds_download", "", "SDS downloads", "ops", family, "oiofs.sds_dl")
-	sdsDownload.AddDimension("sds_download_failed", "failed", netdata.IncrementalAlgorithm)
-	sdsDownload.AddDimension("sds_download_succeeded", "succeeded", netdata.IncrementalAlgorithm)
-	worker.AddChart(sdsDownload)
-
-	sdsData := netdata.NewChart(fsType, "sds_data", "", "SDS data", "bytes", family, "oiofs.sds")
-	sdsData.AddDimension("sds_download_total_byte", "download", netdata.IncrementalAlgorithm)
-	sdsData.AddDimension("sds_upload_total_byte", "upload", netdata.IncrementalAlgorithm)
-	worker.AddChart(sdsData)
 
 	worker.Run()
 }

--- a/command/command.go
+++ b/command/command.go
@@ -33,7 +33,7 @@ type Command struct {
 
 type Worker interface {
 	SinceLastRun() time.Duration
-	AddChart(chart *netdata.Chart)
+	AddChart(chart *netdata.Chart, collector ...netdata.Collector)
 }
 
 type collector struct {

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -28,7 +28,7 @@ func (w *FakeWorker) SinceLastRun() time.Duration {
 	return 1000 * time.Second
 }
 
-func (w *FakeWorker) AddChart(chart *netdata.Chart) {
+func (w *FakeWorker) AddChart(chart *netdata.Chart, collector ...netdata.Collector) {
 	return
 }
 

--- a/container/container.go
+++ b/container/container.go
@@ -109,17 +109,16 @@ func Collect(client *redis.Client, ns string, l int64, t int64, f bool, c chan n
 		if err != nil {
 			return err
 		}
-		for _, data := range(acctObj) {
+		for _, data := range acctObj {
 			val, err := strconv.Atoi(data[1])
 			if err != nil {
 				return err
 			}
 			netdata.Update("account_bytes", util.AcctID(ns, data[0]), data[1], c)
-			netdata.Update("account_kilobytes", util.AcctID(ns, data[0]), strconv.Itoa(val / 1000), c)
+			netdata.Update("account_kilobytes", util.AcctID(ns, data[0]), strconv.Itoa(val/1000), c)
 			netdata.Update("account_objects", util.AcctID(ns, data[0]), data[2], c)
 		}
 	}
-
 
 	for _, acct := range accounts.([]interface{}) {
 		if acct == "1" {

--- a/netdata/charts.go
+++ b/netdata/charts.go
@@ -44,6 +44,8 @@ type Chart struct {
 	refresh bool
 }
 
+type Charts map[string]*Chart
+
 func NewChart(chartType, id, name, title, units, family, category string) *Chart {
 	return &Chart{
 		Type:       chartType,
@@ -114,5 +116,3 @@ func (c *Chart) Update(data map[string]string, interval time.Duration, out Write
 
 	return false
 }
-
-type Charts map[string]*Chart

--- a/oiofs/oiofs.go
+++ b/oiofs/oiofs.go
@@ -25,6 +25,12 @@ import (
 	"strings"
 )
 
+// Endpoint defined an oiofs endpoint to monitor
+type Endpoint struct {
+	URL  string
+	Path string
+}
+
 // Ops defines all possible metrics
 var Ops = map[string][]string{
 	"metaPrefix": []string{"Meta"},
@@ -58,12 +64,12 @@ var Ops = map[string][]string{
 }
 
 type collector struct {
-	addr      string
+	endpoint  Endpoint
 	full      bool
 	whitelist map[string]int64
 }
 
-func NewCollector(addr string, full bool) *collector {
+func NewCollector(endpoint Endpoint, full bool) *collector {
 	var whitelist = map[string]int64{}
 	// Generate whitelist of metrics to keep
 	for _, p := range []string{"meta", "sds", "fuse", "cache"} {
@@ -83,7 +89,7 @@ func NewCollector(addr string, full bool) *collector {
 	}
 
 	return &collector{
-		addr:      addr,
+		endpoint:  endpoint,
 		full:      full,
 		whitelist: whitelist,
 	}
@@ -91,7 +97,8 @@ func NewCollector(addr string, full bool) *collector {
 
 func (c *collector) Collect() (map[string]string, error) {
 	// TODO: support v2
-	r, err := http.Get(fmt.Sprintf("http://%s/stats", c.addr))
+
+	r, err := http.Get(fmt.Sprintf("http://%s/stats", c.endpoint.URL))
 	if err != nil {
 		return nil, err
 	}
@@ -117,5 +124,6 @@ func (c *collector) Collect() (map[string]string, error) {
 			res[k] = "0"
 		}
 	}
+
 	return res, nil
 }

--- a/openio/openio.go
+++ b/openio/openio.go
@@ -99,15 +99,6 @@ func ZookeeperAddr(basePath string, ns string) (string, error) {
 	return "", fmt.Errorf("no local zookeeper address found for %s", ns)
 }
 
-// Commands retrieves commands to execute on each node
-func Commands(path string) (map[string]string, error) {
-	conf, err := util.ReadConf(path, "=")
-	if err != nil {
-		return nil, err
-	}
-	return conf, err
-}
-
 func diffCounter(metric string, sid string, value string) string {
 	res := ""
 	curr, err := strconv.Atoi(value)

--- a/util/util.go
+++ b/util/util.go
@@ -132,6 +132,24 @@ func AcctID(ns string, acct string, cont ...string) string {
 	return fmt.Sprintf("%s.%s", ns, mReplacer.Replace(acct))
 }
 
+// Commands retrieves commands to execute on each node
+func Commands(path string) (map[string]string, error) {
+	conf, err := ReadConf(path, "=")
+	if err != nil {
+		return nil, err
+	}
+	return conf, err
+}
+
+// OiofsEndpoints retrieves oiofs endpoints to monitor
+func OiofsEndpoints(path string) (map[string]string, error) {
+	conf, err := ReadConf(path, "=")
+	if err != nil {
+		return nil, err
+	}
+	return conf, err
+}
+
 func ReadConf(path string, separator string) (map[string]string, error) {
 	file, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
Previously we would need a different instance of the collector for each oiofs endpoint.
Now all endpoints are monitored simultaneously and are declared in a config file as follows

```
/mnt/test=localhost:8000
```