### PR TITLE
Improve command collector, lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ notifications:
 before_script:
   - go get github.com/golangci/golangci-lint/cmd/golangci-lint
   - go get github.com/go-redis/redis
+  - go get gopkg.in/yaml.v2
   - go get github.com/aws/aws-sdk-go
   - go get github.com/golang/mock/gomock
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ cd
 $ git clone [this repo] go/src/oionetdata
 $ go get github.com/go-redis/redis
 $ go get github.com/aws/aws-sdk-go
+$ go get gopkg.in/yaml.v2
 $ export GOPATH=${GOPATH:-$(go env GOPATH)}:$(pwd)/go/
 $ cd $(pwd)/go/src/oionetdata
 $ go build ./cmd/openio.plugin/openio.plugin.go;
@@ -104,6 +105,29 @@ object=file-roundtrip
 timeout=3
 ```
 
+Since 0.6.0, netdata config files have the following format:
+```
+# /etc/netdata/commands.yml
+config:
+  - name: openio_version
+    command: "rpm -q --qf '%{VERSION}\n' openio-sds-server"
+    interval: 60
+    family: version
+    value_is_label: true
+  - name: swift_version
+    command: "rpm -q --qf '%{VERSION}\n' openio-sds-swift
+    interval: 60
+    family: version
+    value_is_label: true
+  - name: swift_version
+    command: "rpm -q --qf '%{VERSION}\n' openio-sds-swift
+    interval: 60
+    family: version
+    value_is_label: true
+[...]
+```
+
+For backward-compatibility, .conf files are still accepted:
 ```
 # /etc/netdata/commands.conf
 openio_version=rpm -q --qf "%{VERSION}\n" openio-sds-server

--- a/netdata/worker.go
+++ b/netdata/worker.go
@@ -98,10 +98,6 @@ func (w *worker) Run() {
 }
 
 func (w *worker) process() {
-	sleepTime := w.interval
-
-	w.sleep(sleepTime)
-
 	w.startRun = time.Now()
 
 	var sinceUpdate time.Duration
@@ -119,6 +115,8 @@ func (w *worker) process() {
 		w.lastUpdate = w.startRun
 		log.Printf("elapsed: %v", w.elapsed)
 	}
+
+	w.sleep(w.interval)
 }
 
 func (w *worker) sleep(sleepTime time.Duration) {

--- a/oiofs/oiofs_test.go
+++ b/oiofs/oiofs_test.go
@@ -19,12 +19,12 @@ package oiofs
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
+	"net"
 	"net/http"
 	"strconv"
 	"testing"
-	"log"
 	"time"
-	"net"
 )
 
 var testEndpoints = []Endpoint{
@@ -96,7 +96,7 @@ func TestOiofsCollector(t *testing.T) {
 	for {
 		now := time.Now()
 		elapsed := now.Sub(start)
-		if elapsed > 30 * time.Second {
+		if elapsed > 30*time.Second {
 			t.Fatal("Could not connect to testserver endpoints")
 		}
 		errors := 0
@@ -114,7 +114,6 @@ func TestOiofsCollector(t *testing.T) {
 		}
 		time.Sleep(time.Second)
 	}
-
 
 	for _, test := range []int{0, 1} {
 		func(full int) {

--- a/openio/openio_test.go
+++ b/openio/openio_test.go
@@ -19,16 +19,16 @@ package openio
 import (
 	"fmt"
 	"io/ioutil"
-	"net/http"
-	"testing"
-    "time"
-    "oionetdata/netdata"
 	"log"
+	"net/http"
+	"oionetdata/netdata"
+	"testing"
+	"time"
 )
 
 var testAddr = "127.0.0.1:6006"
 
-type testServer struct {}
+type testServer struct{}
 
 func newTestServer() *testServer {
 	return &testServer{}
@@ -43,23 +43,23 @@ func (s *testServer) Run() {
 		fmt.Fprintf(w, string(b))
 	})
 
-    http.HandleFunc("/v3.0/OPENIO/conscience/info", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/v3.0/OPENIO/conscience/info", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w,
-"[\"account\",\"beanstalkd\",\"meta0\",\"meta1\",\"meta2\",\"oioproxy\",\"rawx\",\"rdir\",\"redis\",\"sqlx\"]")
+			"[\"account\",\"beanstalkd\",\"meta0\",\"meta1\",\"meta2\",\"oioproxy\",\"rawx\",\"rdir\",\"redis\",\"sqlx\"]")
 	})
 
-    http.HandleFunc("/v3.0/OPENIO/conscience/list", func(w http.ResponseWriter, r *http.Request) {
-        b, err := ioutil.ReadFile(fmt.Sprintf("./testdata/types_%s.json", r.URL.Query().Get("type")))
+	http.HandleFunc("/v3.0/OPENIO/conscience/list", func(w http.ResponseWriter, r *http.Request) {
+		b, err := ioutil.ReadFile(fmt.Sprintf("./testdata/types_%s.json", r.URL.Query().Get("type")))
 		if err != nil {
-            fmt.Println("Warning, type not implemented", r.URL.Query().Get("type"))
+			fmt.Println("Warning, type not implemented", r.URL.Query().Get("type"))
 			fmt.Fprintf(w, "[]")
-            return
+			return
 		}
 		fmt.Fprintf(w, string(b))
 	})
 
-    http.HandleFunc("/v3.0/OPENIO/forward/stats", func(w http.ResponseWriter, r *http.Request) {
-        // Not implemented
+	http.HandleFunc("/v3.0/OPENIO/forward/stats", func(w http.ResponseWriter, r *http.Request) {
+		// Not implemented
 		// b, err := ioutil.ReadFile("./testdata/stat_metax")
 		// if err != nil {
 		// 	fmt.Print(err)
@@ -67,8 +67,8 @@ func (s *testServer) Run() {
 		// fmt.Fprintf(w, string(b))
 	})
 
-    http.HandleFunc("/v3.0/OPENIO/forward/info", func(w http.ResponseWriter, r *http.Request) {
-        // Not implemented
+	http.HandleFunc("/v3.0/OPENIO/forward/info", func(w http.ResponseWriter, r *http.Request) {
+		// Not implemented
 		// b, err := ioutil.ReadFile(s.specFile)
 		// if err != nil {
 		// 	fmt.Print(err)
@@ -81,18 +81,17 @@ func (s *testServer) Run() {
 	}
 }
 
-
 func TestOpenIOCollector(t *testing.T) {
 	srv := newTestServer()
 	go srv.Run()
 
-    c := make(chan netdata.Metric, 1e5)
+	c := make(chan netdata.Metric, 1e5)
 	go Collect(testAddr, "OPENIO", c)
 
-    time.Sleep(time.Duration(2) * time.Second)
-    close(c)
-    // for m := range c {
-    //     // fmt.Println(m)
-    //     // buf[m.Chart] = append(buf[m.Chart], fmt.Sprintf("SET %s %s\n", m.Dim, m.Value)...)
-    // }
+	time.Sleep(time.Duration(2) * time.Second)
+	close(c)
+	// for m := range c {
+	//     // fmt.Println(m)
+	//     // buf[m.Chart] = append(buf[m.Chart], fmt.Sprintf("SET %s %s\n", m.Dim, m.Value)...)
+	// }
 }

--- a/zookeeper/zookeeper_test.go
+++ b/zookeeper/zookeeper_test.go
@@ -19,10 +19,10 @@ package zookeeper
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"net"
 	"reflect"
 	"testing"
-	"log"
 )
 
 type testServer struct {


### PR DESCRIPTION
This adds yaml file support to command collectors, aswell as
configurable intervals for single commands.

Also, values can now be reported either as labels or as values (if
compatible) and label return value can be forced if output is uncertain.

This maintains compatibility with old command configuration file
(key=value) by maintain a set of default values