### PR TITLE
Add redis collector

### DIFF
--- a/cmd/redis.plugin/redis.plugin.go
+++ b/cmd/redis.plugin/redis.plugin.go
@@ -1,0 +1,116 @@
+// OpenIO netdata collectors
+// Copyright (C) 2019 OpenIO SAS
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+	"oionetdata/collector"
+	"oionetdata/netdata"
+	"oionetdata/redis"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("argument required")
+	}
+	var targets string
+	fs := flag.NewFlagSet("", flag.ExitOnError)
+	fs.StringVar(&targets, "targets", "", "Comma separated list of Redis IP:PORT:CLUSTER_ID")
+	err := fs.Parse(os.Args[2:])
+	if err != nil {
+		log.Fatalln("ERROR: Redis plugin: Could not parse args", err)
+	}
+	intervalSeconds := collector.ParseIntervalSeconds(os.Args[1])
+
+	if targets == "" {
+		log.Fatalln("ERROR: Redis plugin: missing targets")
+	}
+
+	writer := netdata.NewDefaultWriter()
+	worker := netdata.NewWorker(time.Duration(intervalSeconds)*time.Second, writer)
+
+	for _, addr := range strings.Split(targets, ",") {
+		collector := redis.NewCollector(addr)
+		worker.AddCollector(collector)
+		instance := "redis." + addr // TODO colon?
+
+		keysChart := netdata.NewChart(instance, "keys", "", "Keys", "count", instance, "redis.keys.")
+		keysChart.AddDimension(
+			fmt.Sprintf("keys"),
+			"keys",
+			netdata.AbsoluteAlgorithm, //netdata.IncrementalAlgorithm,
+		)
+		worker.AddChart(keysChart, collector)
+
+		memChart := netdata.NewChart(instance, "memory", "", "Memory", "bytes", instance, "redis.memory")
+		for k, v := range map[string]string{
+			"used_memory": "total", "used_memory_rss": "rss", "used_memory_lua": "lua"} {
+			memChart.AddDimension(k, v, netdata.AbsoluteAlgorithm) //netdata.IncrementalAlgorithm,)
+		}
+		worker.AddChart(memChart, collector)
+
+		bandwidthChart := netdata.NewChart(instance, "net", "", "Network traffic", "bytes", instance, "redis.net")
+		for k, v := range map[string]string{"total_net_input_bytes": "received", "total_net_output_bytes": "sent"} {
+			bandwidthChart.AddDimension(k, v, netdata.IncrementalAlgorithm) //netdata.IncrementalAlgorithm,)
+		}
+		worker.AddChart(bandwidthChart, collector)
+
+		opsChart := netdata.NewChart(instance, "instant", "", "Instantaneous operations", "ops", instance, "redis.ops")
+		opsChart.AddDimension("instantaneous_ops_per_sec", "ops", netdata.AbsoluteAlgorithm)
+		worker.AddChart(opsChart, collector)
+
+		masterChart := netdata.NewChart(instance, "state", "", "Instance is master", "master", instance, "redis.master")
+		masterChart.AddDimension("is_master", "state", netdata.AbsoluteAlgorithm)
+		worker.AddChart(masterChart, collector)
+
+		replicaCharts := netdata.NewChart(instance, "replicas", "", "Replicas", "count", instance, "redis.replicas")
+		replicaCharts.AddDimension("connected_slaves", "replicas", netdata.AbsoluteAlgorithm)
+		worker.AddChart(replicaCharts, collector)
+
+		cacheCharts := netdata.NewChart(instance, "cache", "", "Cache", "ops", instance, "redis.cache")
+		cacheCharts.AddDimension("keyspace_hits", "hits", netdata.AbsoluteAlgorithm)
+		cacheCharts.AddDimension("keyspace_misses", "misses", netdata.AbsoluteAlgorithm)
+		worker.AddChart(cacheCharts, collector)
+
+		backlogCharts := netdata.NewChart(instance, "backlog", "", "Backlog", "bytes", instance, "redis.backlog")
+		backlogCharts.AddDimension("repl_backlog_size", "backlog", netdata.AbsoluteAlgorithm)
+		worker.AddChart(backlogCharts, collector)
+
+		changesSinceSave := netdata.NewChart(instance, "changes", "", "Changes since last save", "ops", instance, "redis.changes")
+		changesSinceSave.AddDimension("rdb_changes_since_last_save", "changes", netdata.AbsoluteAlgorithm)
+		worker.AddChart(changesSinceSave, collector)
+
+		connCharts := netdata.NewChart(instance, "connections", "", "Connections", "count", instance, "redis.connections")
+		connCharts.AddDimension("total_connections_received", "connections", netdata.AbsoluteAlgorithm)
+		worker.AddChart(connCharts, collector)
+
+		commandCharts := netdata.NewChart(instance, "commands", "", "Commands", "count", instance, "redis.commands")
+		commandCharts.AddDimension("total_commands_processed", "commands", netdata.AbsoluteAlgorithm)
+		worker.AddChart(commandCharts, collector)
+
+		memFragmentCharts := netdata.NewChart(instance, "fragmentation", "", "Memory fragmentation", "ratio", instance, "redis.fragmentation")
+		memFragmentCharts.AddDimension("mem_fragmentation_ratio", "fragmentation", netdata.AbsoluteAlgorithm)
+		worker.AddChart(memFragmentCharts, collector)
+	}
+
+	worker.Run()
+}

--- a/cmd/redis.plugin/redis.plugin.go
+++ b/cmd/redis.plugin/redis.plugin.go
@@ -20,12 +20,12 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
-	"strings"
-	"time"
 	"oionetdata/collector"
 	"oionetdata/netdata"
 	"oionetdata/redis"
+	"os"
+	"strings"
+	"time"
 )
 
 func main() {

--- a/netdata/worker.go
+++ b/netdata/worker.go
@@ -141,7 +141,7 @@ func (w *worker) update(interval time.Duration) (bool, error) {
 		} else {
 			log.Printf("Failed to update: collector not found")
 			log.Println(collector)
-			log.Println(w.chartsIndex)
+			log.Println("Charts index", w.chartsIndex)
 		}
 
 		if !updated {

--- a/oiofs/oiofs_test.go
+++ b/oiofs/oiofs_test.go
@@ -48,7 +48,10 @@ func (s *testServer) Run() {
 		if err != nil {
 			fmt.Print(err)
 		}
-		fmt.Fprintf(w, string(b))
+		_, err = w.Write(b)
+		if err != nil {
+			fmt.Print(err)
+		}
 	})
 	err := http.ListenAndServe(s.addr, server)
 	if err != nil {

--- a/openio/openio_test.go
+++ b/openio/openio_test.go
@@ -40,7 +40,10 @@ func (s *testServer) Run() {
 		if err != nil {
 			fmt.Print(err)
 		}
-		fmt.Fprintf(w, string(b))
+		_, err = w.Write(b)
+		if err != nil {
+			fmt.Print(err)
+		}
 	})
 
 	http.HandleFunc("/v3.0/OPENIO/conscience/info", func(w http.ResponseWriter, r *http.Request) {
@@ -52,10 +55,16 @@ func (s *testServer) Run() {
 		b, err := ioutil.ReadFile(fmt.Sprintf("./testdata/types_%s.json", r.URL.Query().Get("type")))
 		if err != nil {
 			fmt.Println("Warning, type not implemented", r.URL.Query().Get("type"))
-			fmt.Fprintf(w, "[]")
+			_, err = w.Write([]byte("[]"))
+			if err != nil {
+				fmt.Print(err)
+			}
 			return
 		}
-		fmt.Fprintf(w, string(b))
+		_, err = w.Write(b)
+		if err != nil {
+			fmt.Print(err)
+		}
 	})
 
 	http.HandleFunc("/v3.0/OPENIO/forward/stats", func(w http.ResponseWriter, r *http.Request) {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,0 +1,114 @@
+// OpenIO netdata collectors
+// Copyright (C) 2019 OpenIO SAS
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package redis
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"regexp"
+	"fmt"
+	"os"
+	"log"
+)
+
+type collector struct {
+	addr string
+	cluster string
+}
+
+func NewCollector(addr string) *collector {
+	res := strings.Split(addr, ":")
+	if len(res) != 3 {
+		log.Fatalln("Invalid address", addr, "must be IP:PORT:CLUSTER_ID")
+	}
+	return &collector{
+		addr: res[0] + ":" + res[1],
+		cluster: res[2],
+	}
+}
+
+var whitelist = map[string]bool {
+	"used_memory": true,
+	"used_memory_rss": true,
+	"used_memory_lua": true,
+	"mem_fragmentation_ratio": true,
+	"rdb_changes_since_last_save": true,
+	"total_connections_received": true,
+	"total_commands_processed": true,
+	"instantaneous_ops_per_sec": true,
+	"total_net_input_bytes": true,
+	"total_net_output_bytes": true,
+	"keyspace_hits": true,
+	"keyspace_misses": true,
+	"role": true,
+	"connected_slaves": true,
+	"repl_backlog_size": true,
+	"db0": true, // Note: VDO: maybe add support for other db?
+}
+
+var keysRegexp = regexp.MustCompile(`keys=(\d+)`)
+
+func (c *collector) Collect() (map[string]string, error) {
+	conn, err := net.Dial("tcp", c.addr)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	_, err = conn.Write([]byte("INFO\r\nQUIT\r\n"))
+	if err != nil {
+		return nil, err
+	}
+
+	data := map[string]string{}
+
+	scanner := bufio.NewScanner(conn)
+	for scanner.Scan() {
+		line := scanner.Text()
+		kv := strings.Split(line, ":")
+		if len(kv) != 2 {
+			continue
+		}
+		if _, ok := whitelist[kv[0]]; ok {
+			switch true {
+				// Match keys in db entry
+				case strings.HasPrefix(kv[0], "db"):
+					keys := keysRegexp.FindStringSubmatch(kv[1])
+					if len(keys) > 1 {
+						data["keys"] = keys[1]
+					} else {
+						fmt.Fprintln(os.Stderr, "WARN: received unparseable db notation", kv[1])
+					}
+				// Format role:master or role:slave
+				case kv[0] == "role":
+					if kv[1] == "master" {
+						data["is_master"] = "1"
+					} else {
+						data["is_master"] = "0"
+					}
+				default:
+					data[kv[0]] = kv[1]
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return data, nil
+}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -27,7 +27,6 @@ import (
 
 type collector struct {
 	addr    string
-	cluster string
 }
 
 func NewCollector(addr string) *collector {

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -18,16 +18,16 @@ package redis
 
 import (
 	"bufio"
-	"net"
-	"strings"
-	"regexp"
 	"fmt"
-	"os"
 	"log"
+	"net"
+	"os"
+	"regexp"
+	"strings"
 )
 
 type collector struct {
-	addr string
+	addr    string
 	cluster string
 }
 
@@ -37,28 +37,28 @@ func NewCollector(addr string) *collector {
 		log.Fatalln("Invalid address", addr, "must be IP:PORT:CLUSTER_ID")
 	}
 	return &collector{
-		addr: res[0] + ":" + res[1],
+		addr:    res[0] + ":" + res[1],
 		cluster: res[2],
 	}
 }
 
-var whitelist = map[string]bool {
-	"used_memory": true,
-	"used_memory_rss": true,
-	"used_memory_lua": true,
-	"mem_fragmentation_ratio": true,
+var whitelist = map[string]bool{
+	"used_memory":                 true,
+	"used_memory_rss":             true,
+	"used_memory_lua":             true,
+	"mem_fragmentation_ratio":     true,
 	"rdb_changes_since_last_save": true,
-	"total_connections_received": true,
-	"total_commands_processed": true,
-	"instantaneous_ops_per_sec": true,
-	"total_net_input_bytes": true,
-	"total_net_output_bytes": true,
-	"keyspace_hits": true,
-	"keyspace_misses": true,
-	"role": true,
-	"connected_slaves": true,
-	"repl_backlog_size": true,
-	"db0": true, // Note: VDO: maybe add support for other db?
+	"total_connections_received":  true,
+	"total_commands_processed":    true,
+	"instantaneous_ops_per_sec":   true,
+	"total_net_input_bytes":       true,
+	"total_net_output_bytes":      true,
+	"keyspace_hits":               true,
+	"keyspace_misses":             true,
+	"role":                        true,
+	"connected_slaves":            true,
+	"repl_backlog_size":           true,
+	"db0":                         true, // Note: VDO: maybe add support for other db?
 }
 
 var keysRegexp = regexp.MustCompile(`keys=(\d+)`)
@@ -86,23 +86,23 @@ func (c *collector) Collect() (map[string]string, error) {
 		}
 		if _, ok := whitelist[kv[0]]; ok {
 			switch true {
-				// Match keys in db entry
-				case strings.HasPrefix(kv[0], "db"):
-					keys := keysRegexp.FindStringSubmatch(kv[1])
-					if len(keys) > 1 {
-						data["keys"] = keys[1]
-					} else {
-						fmt.Fprintln(os.Stderr, "WARN: received unparseable db notation", kv[1])
-					}
-				// Format role:master or role:slave
-				case kv[0] == "role":
-					if kv[1] == "master" {
-						data["is_master"] = "1"
-					} else {
-						data["is_master"] = "0"
-					}
-				default:
-					data[kv[0]] = kv[1]
+			// Match keys in db entry
+			case strings.HasPrefix(kv[0], "db"):
+				keys := keysRegexp.FindStringSubmatch(kv[1])
+				if len(keys) > 1 {
+					data["keys"] = keys[1]
+				} else {
+					fmt.Fprintln(os.Stderr, "WARN: received unparseable db notation", kv[1])
+				}
+			// Format role:master or role:slave
+			case kv[0] == "role":
+				if kv[1] == "master" {
+					data["is_master"] = "1"
+				} else {
+					data["is_master"] = "0"
+				}
+			default:
+				data[kv[0]] = kv[1]
 			}
 		}
 	}

--- a/redis/redis.spec.txt
+++ b/redis/redis.spec.txt
@@ -1,0 +1,101 @@
+# Server
+redis_version:3.2.12
+redis_git_sha1:00000000
+redis_git_dirty:0
+redis_build_id:7897e7d0e13773f
+redis_mode:standalone
+os:Linux 5.2.13-arch1-1-ARCH x86_64
+arch_bits:64
+multiplexing_api:epoll
+gcc_version:4.8.5
+process_id:99
+run_id:15c948a7073835ef2726fdc7d4584a3b16fbdfd9
+tcp_port:6011
+uptime_in_seconds:493
+uptime_in_days:0
+hz:10
+lru_clock:13793213
+executable:/usr/bin/redis-server
+config_file:/etc/oio/sds/OPENIO/redis-0/redis.conf
+
+# Clients
+connected_clients:8
+client_longest_output_list:0
+client_biggest_input_buf:0
+blocked_clients:0
+
+# Memory
+used_memory:2038864
+used_memory_human:1.94M
+used_memory_rss:4464640
+used_memory_rss_human:4.26M
+used_memory_peak:2127536
+used_memory_peak_human:2.03M
+total_system_memory:16696946688
+total_system_memory_human:15.55G
+used_memory_lua:46080
+used_memory_lua_human:45.00K
+maxmemory:0
+maxmemory_human:0B
+maxmemory_policy:noeviction
+mem_fragmentation_ratio:2.19
+mem_allocator:jemalloc-3.6.0
+
+# Persistence
+loading:0
+rdb_changes_since_last_save:473
+rdb_bgsave_in_progress:0
+rdb_last_save_time:1574074121
+rdb_last_bgsave_status:ok
+rdb_last_bgsave_time_sec:0
+rdb_current_bgsave_time_sec:-1
+aof_enabled:0
+aof_rewrite_in_progress:0
+aof_rewrite_scheduled:0
+aof_last_rewrite_time_sec:-1
+aof_current_rewrite_time_sec:-1
+aof_last_bgrewrite_status:ok
+aof_last_write_status:ok
+
+# Stats
+total_connections_received:2411
+total_commands_processed:6973
+instantaneous_ops_per_sec:39
+total_net_input_bytes:328478
+total_net_output_bytes:1053126
+instantaneous_input_kbps:1.66
+instantaneous_output_kbps:4.51
+rejected_connections:0
+sync_full:1
+sync_partial_ok:0
+sync_partial_err:0
+expired_keys:0
+evicted_keys:0
+keyspace_hits:2972
+keyspace_misses:176
+pubsub_channels:1
+pubsub_patterns:0
+latest_fork_usec:132
+migrate_cached_sockets:0
+
+# Replication
+role:master
+connected_slaves:1
+slave0:ip=10.10.10.12,port=6011,state=online,offset=197016,lag=1
+master_repl_offset:197493
+repl_backlog_active:1
+repl_backlog_size:1048576
+repl_backlog_first_byte_offset:2
+repl_backlog_histlen:197492
+
+# CPU
+used_cpu_sys:0.72
+used_cpu_user:0.28
+used_cpu_sys_children:0.00
+used_cpu_user_children:0.00
+
+# Cluster
+cluster_enabled:0
+
+# Keyspace
+db0:keys=3,expires=1,avg_ttl=59900

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -18,8 +18,8 @@ package redis
 
 import (
 	"bufio"
-    "io/ioutil"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"reflect"
@@ -27,26 +27,26 @@ import (
 )
 
 type testServer struct {
-    specFile string
+	specFile string
 }
 
 var expected = map[string]string{
-    "connected_slaves":"1",
-    "instantaneous_ops_per_sec":"39",
-    "is_master":"1",
-    "keys":"3",
-    "keyspace_hits":"2972",
-    "keyspace_misses":"176",
-    "mem_fragmentation_ratio":"2.19",
-    "rdb_changes_since_last_save":"473",
-    "repl_backlog_size":"1048576",
-    "total_commands_processed":"6973",
-    "total_connections_received":"2411",
-    "total_net_input_bytes":"328478",
-    "total_net_output_bytes":"1053126",
-    "used_memory":"2038864",
-    "used_memory_lua":"46080",
-    "used_memory_rss":"4464640",
+	"connected_slaves":            "1",
+	"instantaneous_ops_per_sec":   "39",
+	"is_master":                   "1",
+	"keys":                        "3",
+	"keyspace_hits":               "2972",
+	"keyspace_misses":             "176",
+	"mem_fragmentation_ratio":     "2.19",
+	"rdb_changes_since_last_save": "473",
+	"repl_backlog_size":           "1048576",
+	"total_commands_processed":    "6973",
+	"total_connections_received":  "2411",
+	"total_net_input_bytes":       "328478",
+	"total_net_output_bytes":      "1053126",
+	"used_memory":                 "2038864",
+	"used_memory_lua":             "46080",
+	"used_memory_rss":             "4464640",
 }
 
 func newTestServer(specFile string) *testServer {
@@ -69,16 +69,16 @@ func (s *testServer) handleConn(conn net.Conn) {
 	if err != nil {
 		panic(err)
 	}
-    if data == "QUIT" {
-        return
-    }
+	if data == "QUIT" {
+		return
+	}
 	if data != "INFO\r\n" {
 		log.Fatalf("Unknown command %s", data)
 	}
-    b, err := ioutil.ReadFile(s.specFile)
-    if err != nil {
-        fmt.Print(err)
-    }
+	b, err := ioutil.ReadFile(s.specFile)
+	if err != nil {
+		fmt.Print(err)
+	}
 	buf := bufio.NewWriter(conn)
 	buf.Write(b)
 	buf.Flush()
@@ -104,7 +104,7 @@ func TestRedisCollector(t *testing.T) {
 		t.Fatalf("unexpected result got\n%v\nexpected\n%v\n", data, expected)
 	}
 
-    l.Close()
+	l.Close()
 	_, err = collector.Collect()
 	if err == nil {
 		t.Fatalf("expected error")

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -1,0 +1,112 @@
+// OpenIO netdata collectors
+// Copyright (C) 2019 OpenIO SAS
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 3.0 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package redis
+
+import (
+	"bufio"
+    "io/ioutil"
+	"fmt"
+	"log"
+	"net"
+	"reflect"
+	"testing"
+)
+
+type testServer struct {
+    specFile string
+}
+
+var expected = map[string]string{
+    "connected_slaves":"1",
+    "instantaneous_ops_per_sec":"39",
+    "is_master":"1",
+    "keys":"3",
+    "keyspace_hits":"2972",
+    "keyspace_misses":"176",
+    "mem_fragmentation_ratio":"2.19",
+    "rdb_changes_since_last_save":"473",
+    "repl_backlog_size":"1048576",
+    "total_commands_processed":"6973",
+    "total_connections_received":"2411",
+    "total_net_input_bytes":"328478",
+    "total_net_output_bytes":"1053126",
+    "used_memory":"2038864",
+    "used_memory_lua":"46080",
+    "used_memory_rss":"4464640",
+}
+
+func newTestServer(specFile string) *testServer {
+	return &testServer{specFile: specFile}
+}
+
+func (s *testServer) Run(l net.Listener) {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			log.Printf("WARN: %s", err)
+			return
+		}
+		go s.handleConn(conn)
+	}
+}
+
+func (s *testServer) handleConn(conn net.Conn) {
+	data, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		panic(err)
+	}
+    if data == "QUIT" {
+        return
+    }
+	if data != "INFO\r\n" {
+		log.Fatalf("Unknown command %s", data)
+	}
+    b, err := ioutil.ReadFile(s.specFile)
+    if err != nil {
+        fmt.Print(err)
+    }
+	buf := bufio.NewWriter(conn)
+	buf.Write(b)
+	buf.Flush()
+	conn.Close()
+}
+
+func TestRedisCollector(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+
+	if err != nil {
+		t.Fatalf("listen error: %v", err)
+	}
+	redis := newTestServer("./redis.spec.txt")
+	go redis.Run(l)
+
+	collector := NewCollector(l.Addr().String() + ":0")
+	data, err := collector.Collect()
+	if err != nil {
+		t.Fatalf("unexpected Collect error: %v", err)
+	}
+
+	if !reflect.DeepEqual(data, expected) {
+		t.Fatalf("unexpected result got\n%v\nexpected\n%v\n", data, expected)
+	}
+
+    l.Close()
+	_, err = collector.Collect()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -80,7 +80,10 @@ func (s *testServer) handleConn(conn net.Conn) {
 		fmt.Print(err)
 	}
 	buf := bufio.NewWriter(conn)
-	buf.Write(b)
+	_, err = buf.Write(b)
+	if err != nil {
+		fmt.Print(err)
+	}
 	buf.Flush()
 	conn.Close()
 }

--- a/redis/redis_test.go
+++ b/redis/redis_test.go
@@ -97,7 +97,7 @@ func TestRedisCollector(t *testing.T) {
 	redis := newTestServer("./redis.spec.txt")
 	go redis.Run(l)
 
-	collector := NewCollector(l.Addr().String() + ":0")
+	collector := NewCollector(l.Addr().String())
 	data, err := collector.Collect()
 	if err != nil {
 		t.Fatalf("unexpected Collect error: %v", err)


### PR DESCRIPTION
This plugin collects redis information. It can be used to monitor multiple redis instances on the node. Below are the collected metrics:

- memory used (total/rss/lua)
- keys
- memory fragmentation ratio
- changes to rdb since last save
- connections
- commands
- operations per sec
- bytes in/out
- cache hits/misses
- if instance is master
- number of connected replicas
- replication backlog size

To deploy with netdata, use the following configuration:

```
[plugin:redis]
  update_every = 10
  command options = --targets "10.10.10.11:6011:0,10.10.10.12:6011:1"
```

> Note: you must provide a cluster id after each IP:PORT to help identify which cluster the redis instance belongs to.