### PR TITLE
Redis collector: reset number of slaves when not master

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -92,6 +92,7 @@ func (c *collector) Collect() (map[string]string, error) {
 					data["is_master"] = "1"
 				} else {
 					data["is_master"] = "0"
+					data["connected_slaves"] = "0"
 				}
 			} else {
 				data[kv[0]] = kv[1]


### PR DESCRIPTION
The `connected_slaves` metric would otherwise not be reported when redis switches from master to slave, making it stale on Prometheus side (same instant value).