### PR TITLE
OpenIO: Prevent the collector from exiting

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -140,7 +140,9 @@ func Collect(client *redis.Client, ns string, l int64, t int64, f bool, c chan n
 				}
 				contObj := map[string][]int{}
 				err = json.Unmarshal([]byte(res.(string)), &contObj)
-				util.RaiseIf(err)
+				if err != nil {
+					return err
+				}
 				for cont, values := range contObj {
 					netdata.Update("container_objects", util.AcctID(ns, acct.(string), cont), strconv.Itoa(values[0]), c)
 					netdata.Update("container_bytes", util.AcctID(ns, acct.(string), cont), strconv.Itoa(values[1]), c)

--- a/openio/openio.go
+++ b/openio/openio.go
@@ -117,9 +117,17 @@ func diffCounter(metric string, sid string, value string) string {
 Collect - collect openio metrics
 */
 func Collect(proxyURL string, ns string, c chan netdata.Metric) {
-	var sType = serviceTypes(proxyURL, ns)
+	sType, err := serviceTypes(proxyURL, ns)
+	if err != nil {
+		log.Println("WARN: couldn't retrieve service types", err)
+		return
+	}
 	for t := range sType {
-		var sInfo = collectScore(proxyURL, ns, sType[t], c)
+		sInfo, err := collectScore(proxyURL, ns, sType[t], c)
+		if err != nil {
+			log.Println("WARN: could not retrieve services of type", sType[t], err)
+			continue
+		}
 		if sType[t] == "rawx" {
 			for sc := range sInfo {
 				if sInfo[sc].Local {
@@ -139,25 +147,27 @@ func Collect(proxyURL string, ns string, c chan netdata.Metric) {
 	}
 }
 
-func serviceTypes(proxyURL string, ns string) serviceType {
+func serviceTypes(proxyURL string, ns string) (serviceType, error) {
 	url := fmt.Sprintf("http://%s/v3.0/%s/conscience/info?what=types", proxyURL, ns)
 	res := serviceType{}
 
 	typesResponse, err := util.HTTPGet(url)
-	if err == nil {
-		util.RaiseIf(json.Unmarshal([]byte(typesResponse), &res))
+	if err != nil {
+		return nil, err
 	}
-	return res
+	err = json.Unmarshal([]byte(typesResponse), &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }
 
-/*
-CollectRawx - update metrics for Rawx services
-*/
 func collectRawx(ns string, service string, c chan netdata.Metric) {
 	url := fmt.Sprintf("http://%s/stat", service)
 	res, err := util.HTTPGet(url)
 	if err != nil {
-		log.Println("DEBUG: rawx metric collection failed", err)
+		log.Println("WARN: rawx metric collection failed", err)
 		return
 	}
 	var lines = strings.Split(res, "\n")
@@ -183,7 +193,7 @@ func collectMetax(ns string, service string, proxyURL string, c chan netdata.Met
 	url := fmt.Sprintf("http://%s/v3.0/forward/stats?id=%s", proxyURL, service)
 	res, err := util.HTTPGet(url)
 	if err != nil {
-		log.Println("DEBUG: metax stats collection failed", err)
+		log.Println("WARN: metaX stats collection failed", err)
 		return
 	}
 	var lines = strings.Split(res, "\n")
@@ -215,12 +225,12 @@ func collectMeta2Info(ns, service, proxyURL string, c chan netdata.Metric) {
 	res, err := util.HTTPGet(url)
 
 	if err != nil {
-		log.Println("DEBUG: meta2 info collection failed", err)
+		log.Println("WARN: meta2 info collection failed", err)
 		return
 	}
 
 	if err = json.Unmarshal([]byte(res), &info); err != nil {
-		log.Println("DEBUG: meta2 info collection failed", err)
+		log.Println("WARN: meta2 info collection failed", err)
 		return
 	}
 
@@ -235,7 +245,7 @@ func collectMeta2Info(ns, service, proxyURL string, c chan netdata.Metric) {
 func volumeInfo(service string, ns string, volume string, c chan netdata.Metric) {
 	info, fsid, err := util.VolumeInfo(volume)
 	if err != nil {
-		log.Println("DEBUG: volume info collection failed", err)
+		log.Println("WARN: volume info collection failed", err)
 		return
 	}
 	for dim, val := range info {
@@ -243,23 +253,24 @@ func volumeInfo(service string, ns string, volume string, c chan netdata.Metric)
 	}
 }
 
-/*
-CollectScore - collect score values on all scored services
-*/
-func collectScore(proxyURL string, ns string, sType string, c chan netdata.Metric) serviceInfo {
+func collectScore(proxyURL string, ns string, sType string, c chan netdata.Metric) (serviceInfo, error) {
 	sInfo := serviceInfo{}
 	url := fmt.Sprintf("http://%s/v3.0/%s/conscience/list?type=%s", proxyURL, ns, sType)
 	res, err := util.HTTPGet(url)
-	if err == nil {
-		util.RaiseIf(json.Unmarshal([]byte(res), &sInfo))
-		for i := range sInfo {
-			if util.IsSameHost(sInfo[i].Addr) {
-				sInfo[i].Local = true
-				netdata.Update("score", util.SID(sType+"_"+sInfo[i].Addr, ns), fmt.Sprint(sInfo[i].Score), c)
-			} else {
-				sInfo[i].Local = false
-			}
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(res), &sInfo)
+	if err != nil {
+		return nil, err
+	}
+	for i := range sInfo {
+		if util.IsSameHost(sInfo[i].Addr) {
+			sInfo[i].Local = true
+			netdata.Update("score", util.SID(sType+"_"+sInfo[i].Addr, ns), fmt.Sprint(sInfo[i].Score), c)
+		} else {
+			sInfo[i].Local = false
 		}
 	}
-	return sInfo
+	return sInfo, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -94,10 +94,12 @@ func HTTPGet(url string) (string, error) {
 	return string(body), nil
 }
 
-func getIPList() map[string]bool {
+func getIPList() (map[string]bool, error) {
 	ipList := make(map[string]bool)
 	ifaces, err := net.InterfaceAddrs()
-	RaiseIf(err)
+	if err != nil {
+		return nil, err
+	}
 	for ip := range ifaces {
 		// TODO: consider adding support for IPv6 here
 		ips := strings.Split(ifaces[ip].String(), "/")[0]
@@ -105,7 +107,7 @@ func getIPList() map[string]bool {
 			ipList[ips] = true
 		}
 	}
-	return ipList
+	return ipList, nil
 }
 
 // IsSameHost -- checks if a service if on the current host
@@ -114,20 +116,16 @@ func IsSameHost(service string) bool {
 		return true
 	}
 	if ipList == nil {
-		ipList = getIPList()
+		var err error
+		ipList, err = getIPList()
+		if err != nil {
+			log.Println("WARN could not determine if same host, assuming not", err)
+			return false
+		}
 	}
 	serviceIP := strings.Split(service, ":")[0]
 	_, ok := ipList[serviceIP]
 	return ok
-}
-
-/*
-RaiseIf - Exit with error
-*/
-func RaiseIf(err error) {
-	if err != nil {
-		log.Fatalln(err)
-	}
 }
 
 // SID -- Get a service ID for netdata


### PR DESCRIPTION
This effectively removes all calls to util.RaiseIf, allowing the
collector do not exit when it can't reach the oioproxy/conscience