### PR TITLE
Command: ensure single value for each command output

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -94,9 +94,10 @@ func (c *collector) Collect() (map[string]string, error) {
 		// Check if the value can be reported as is
 		if _, err := strconv.ParseFloat(value, 64); cmd.ValueIsLabel || err != nil {
 			// Cleanup similar command entries
-			for ch, _ := range c.data {
-				if strings.HasPrefix(ch, "cmd_" + cmd.Name) {
+			for ch := range c.data {
+				if strings.HasPrefix(ch, "cmd_"+cmd.Name) {
 					delete(c.data, ch)
+					break
 				}
 			}
 			chart = fmt.Sprintf("cmd_%s_%v", cmd.Name, value)

--- a/command/command.go
+++ b/command/command.go
@@ -93,7 +93,7 @@ func (c *collector) Collect() (map[string]string, error) {
 
 		// Check if the value can be reported as is
 		if _, err := strconv.ParseFloat(value, 64); cmd.ValueIsLabel || err != nil {
-			// Cleanup similar command entries
+			// Cleanup similar command entries from cache and data
 			for ch := range c.data {
 				if strings.HasPrefix(ch, "cmd_"+cmd.Name) {
 					delete(c.data, ch)
@@ -101,6 +101,12 @@ func (c *collector) Collect() (map[string]string, error) {
 				}
 			}
 			chart = fmt.Sprintf("cmd_%s_%v", cmd.Name, value)
+			for ch := range c.cache {
+				if strings.HasPrefix(ch, "cmd_"+cmd.Name) && ch != chart {
+					delete(c.cache, chart)
+					break
+				}
+			}
 			valueAsLabel = true
 		}
 

--- a/command/command.go
+++ b/command/command.go
@@ -93,6 +93,12 @@ func (c *collector) Collect() (map[string]string, error) {
 
 		// Check if the value can be reported as is
 		if _, err := strconv.ParseFloat(value, 64); cmd.ValueIsLabel || err != nil {
+			// Cleanup similar command entries
+			for ch, _ := range c.data {
+				if strings.HasPrefix(ch, "cmd_" + cmd.Name) {
+					delete(c.data, ch)
+				}
+			}
 			chart = fmt.Sprintf("cmd_%s_%v", cmd.Name, value)
 			valueAsLabel = true
 		}
@@ -109,7 +115,6 @@ func (c *collector) Collect() (map[string]string, error) {
 		}
 		c.data[chart] = value
 	}
-
 	return c.data, nil
 }
 

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -19,9 +19,9 @@ package command
 import (
 	"oionetdata/netdata"
 	"oionetdata/util"
+	"strings"
 	"testing"
 	"time"
-	"strings"
 )
 
 type FakeWorker struct{}
@@ -41,7 +41,7 @@ func keyExists(t *testing.T, data map[string]string, key string) {
 
 func keyPrefixCount(t *testing.T, data map[string]string, prefix string, count int) {
 	counter := 0
-	for key, _ := range data {
+	for key := range data {
 		if strings.HasPrefix(key, prefix) {
 			counter++
 		}
@@ -50,7 +50,6 @@ func keyPrefixCount(t *testing.T, data map[string]string, prefix string, count i
 		t.Fatalf("Expected %d occurrences for prefix %s, got %d: %v", count, prefix, counter, data)
 	}
 }
-
 
 func valueCompare(t *testing.T, data map[string]string, key, value string, equal bool) {
 	if _, ok := data[key]; !ok {


### PR DESCRIPTION
This ensures that each command returns a single value, including the cases where value is actually a label