### PR TITLE
S3Roundtrip: make bucket roundtrip optional

### DIFF
--- a/cmd/s3roundtrip.plugin/s3roundtrip.plugin.go
+++ b/cmd/s3roundtrip.plugin/s3roundtrip.plugin.go
@@ -34,8 +34,10 @@ func main() {
 		log.Fatalf("argument required")
 	}
 	var conf string
+	var rtBucket bool
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 	fs.StringVar(&conf, "conf", "/etc/netdata/s3-roundtrip.conf", "Path to roundtrip config file")
+	fs.BoolVar(&rtBucket, "test-bucket", false, "Monitor bucket operations (create/delete)")
 	err := fs.Parse(os.Args[2:])
 	if err != nil {
 		log.Fatalln("ERROR: S3Roundtrip plugin: Could not parse args", err)
@@ -50,7 +52,7 @@ func main() {
 		log.Fatalln("Could not parse configuration file", err)
 	}
 
-	collector := s3roundtrip.NewCollector(config)
+	collector := s3roundtrip.NewCollector(config, rtBucket)
 	worker.AddCollector(collector)
 
 	responseCode := netdata.NewChart("roundtrip", "response_code", "", "Response code", "ops", collector.Endpoint, "")

--- a/s3roundtrip/s3roundtrip.go
+++ b/s3roundtrip/s3roundtrip.go
@@ -126,7 +126,7 @@ func (c *collector) Collect() (map[string]string, error) {
 	register(&data, "get", code(err), time)
 
 	timeTTFBPut, err := c.s3c.put(c.bucket, c.objectTtfb, c.dataTtfb)
-	if err != nil {
+	if err == nil {
 		registerTtfb(&data, "put", timeTTFBPut)
 		timeTTFBGet, _ := c.s3c.get(c.bucket, c.objectTtfb)
 		registerTtfb(&data, "get", timeTTFBGet)

--- a/s3roundtrip/s3roundtrip_test.go
+++ b/s3roundtrip/s3roundtrip_test.go
@@ -67,6 +67,7 @@ func TestS3Roundtrip(t *testing.T) {
 		dataTtfb:   []byte{},
 		Endpoint:   "test",
 		s3c:        &s3c{s3: mock},
+		rtBucket:   true,
 	}
 	data, err := c.Collect()
 	if err != nil {


### PR DESCRIPTION
Done via the `--test-bucket` flag, defaults to false (no bucket roundtrip, only initial bucket creation will be done).