### PR TITLE
Add ttfb_get_cache

### DIFF
--- a/cmd/s3roundtrip.plugin/s3roundtrip.plugin.go
+++ b/cmd/s3roundtrip.plugin/s3roundtrip.plugin.go
@@ -77,6 +77,7 @@ func main() {
 	ttfb := netdata.NewChart("roundtrip", "ttfb", "", "Time to first byte", "ms", collector.Endpoint, "")
 	ttfb.AddDimension("ttfb_put", "ttfb_put", netdata.AbsoluteAlgorithm)
 	ttfb.AddDimension("ttfb_get", "ttfb_get", netdata.AbsoluteAlgorithm)
+	ttfb.AddDimension("ttfb_get_cache", "ttfb_get_cache", netdata.AbsoluteAlgorithm)
 	worker.AddChart(ttfb, collector)
 
 	worker.Run()

--- a/s3roundtrip/s3roundtrip.go
+++ b/s3roundtrip/s3roundtrip.go
@@ -17,6 +17,7 @@
 package s3roundtrip
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -26,7 +27,6 @@ import (
 	"os"
 	"strconv"
 	"time"
-	"bytes"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -198,7 +198,6 @@ func makeInputOutput(ramBuffers bool, size int) (io.ReadCloser, io.Writer) {
 	return fd, ioutil.Discard
 }
 
-
 func (c *collector) Cleanup() {
 	c.s3c.src.Close()
 }
@@ -228,6 +227,8 @@ func (c *collector) Collect() (map[string]string, error) {
 				registerTtfb(&data, "put", timeTTFBPut)
 				timeTTFBGet, _ := c.s3c.get(c.bucket, obj)
 				registerTtfb(&data, "get", timeTTFBGet)
+				timeTTFBGet, _ := c.s3c.get(c.bucket, obj)
+				registerTtfb(&data, "get_cache", timeTTFBGet)
 				_, _ = c.s3c.del(c.bucket, obj)
 			}
 		default:


### PR DESCRIPTION
Since gateway can use cache to store metadata and chunks positions,
we want to expose a measure between a get without cache from a
get with cache (if enabled on customer side of course)